### PR TITLE
Add retry mechanism and dead-letter queue to Redis worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY . .
 # build api
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o api ./cmd/api
 
+# build worker
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o worker ./cmd/worker
+
 # later cli
 # RUN go build -o cli ./cmd/cli
 
@@ -18,6 +21,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y curl
 
 COPY --from=builder /app/api .
+COPY --from=builder /app/worker .
 
 EXPOSE 8080
 CMD ["./api"]

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -7,6 +7,7 @@ import (
 
 	_ "taskmanager/docs"
 	"taskmanager/internal/api"
+	"taskmanager/internal/queue"
 
 	dbpkg "taskmanager/internal/db"
 	redispkg "taskmanager/internal/redis"
@@ -24,6 +25,9 @@ func main() {
 	}
 	log.Println("Connected to Redis!")
 
+	// queue
+	q := queue.NewRedisQueue(rdb, "jobs")
+
 	// load env
 	envpkg.LoadEnv()
 
@@ -40,7 +44,7 @@ func main() {
 
 	// Start API
 	fmt.Println("Initializing API Program")
-	api.Start(db, rdb)
+	api.Start(db, rdb, q)
 }
 
 func dbInit() (*sql.DB, error) {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -52,20 +52,37 @@ func main() {
 				Title string `json:"title"`
 			}
 
-			err := json.Unmarshal(job.Payload, &payload)
-			if err != nil {
+			if err := json.Unmarshal(job.Payload, &payload); err != nil {
 				log.Println("failed to parse payload:", err)
 				continue
 			}
 
-			_, err = dbpkg.CreateTask(db, payload.Title)
-			if err != nil {
+			if _, err = dbpkg.CreateTask(db, payload.Title); err != nil {
 				log.Println("failed to create task:", err)
 				continue
 			}
 
 			cache.InvalidateTasks(rdb)
 			log.Println("task created:", payload.Title)
+
+		case "delete_task":
+			var payload struct {
+				ID int `json:"id"`
+			}
+
+			if err := json.Unmarshal(job.Payload, &payload); err != nil {
+				log.Println("failed to parse payload:", err)
+				continue
+			}
+
+			if err := dbpkg.DeleteTask(db, payload.ID); err != nil {
+				log.Println("faild to delete task:", err)
+				continue
+
+			}
+
+			cache.InvalidateTasks(rdb)
+			log.Printf("Task %d deleted", payload.ID)
 
 		default:
 			log.Println("unknown job type:", job.Type)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -76,13 +76,31 @@ func main() {
 			}
 
 			if err := dbpkg.DeleteTask(db, payload.ID); err != nil {
-				log.Println("faild to delete task:", err)
+				log.Println("failed to delete task:", err)
 				continue
 
 			}
 
 			cache.InvalidateTasks(rdb)
 			log.Printf("Task %d deleted", payload.ID)
+
+		case "mark_task_done":
+			var payload struct {
+				ID int `json:"id"`
+			}
+
+			if err := json.Unmarshal(job.Payload, &payload); err != nil {
+				log.Println("failed to parse payload:", err)
+				continue
+			}
+
+			if _, err := dbpkg.UpdateTaskStatus(db, payload.ID, true); err != nil {
+				log.Println("failed to update task:", err)
+				continue
+			}
+
+			cache.InvalidateTasks(rdb)
+			log.Printf("Task id - %d has been updated to done", payload.ID)
 
 		default:
 			log.Println("unknown job type:", job.Type)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"taskmanager/internal/queue"
+
+	redispkg "taskmanager/internal/redis"
+)
+
+func main() {
+
+	ctx := redispkg.Ctx
+
+	client := redispkg.NewClient()
+
+	q := queue.NewRedisQueue(client, "jobs")
+
+	log.Println("Worker started... waiting for jobs")
+
+	for {
+		job, err := q.PopJob(ctx)
+		if err != nil {
+			log.Println("error:", err)
+		}
+		log.Println("received job: ", job.Type)
+	}
+}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,27 +1,74 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"log"
+	"taskmanager/internal/cache"
 	"taskmanager/internal/queue"
 
+	envpkg "taskmanager/internal/config"
+	dbpkg "taskmanager/internal/db"
 	redispkg "taskmanager/internal/redis"
 )
 
 func main() {
 
-	ctx := redispkg.Ctx
+	// load env
+	envpkg.LoadEnv()
 
-	client := redispkg.NewClient()
+	// redis
+	rdb := redispkg.NewClient()
+	_, err := rdb.Ping(redispkg.Ctx).Result()
+	if err != nil {
+		log.Fatalf("Failed to connect to Redis: %v", err)
+	}
+	log.Println("worker connected to Redis")
 
-	q := queue.NewRedisQueue(client, "jobs")
+	// queue
+	q := queue.NewRedisQueue(rdb, "jobs")
 
-	log.Println("Worker started... waiting for jobs")
+	// DB
+	db, err := dbpkg.Init()
+	if err != nil {
+		log.Fatalf("Failed to connect to DB: %v", err)
+	}
+	defer db.Close()
+	log.Println("worker connected to DB")
+
+	// worker loop
+	ctx := context.Background()
+	log.Println("worker started... waiting for jobs")
 
 	for {
 		job, err := q.PopJob(ctx)
 		if err != nil {
 			log.Println("error:", err)
 		}
-		log.Println("received job: ", job.Type)
+		switch job.Type {
+
+		case "create_task":
+			var payload struct {
+				Title string `json:"title"`
+			}
+
+			err := json.Unmarshal(job.Payload, &payload)
+			if err != nil {
+				log.Println("failed to parse payload:", err)
+				continue
+			}
+
+			_, err = dbpkg.CreateTask(db, payload.Title)
+			if err != nil {
+				log.Println("failed to create task:", err)
+				continue
+			}
+
+			cache.InvalidateTasks(rdb)
+			log.Println("task created:", payload.Title)
+
+		default:
+			log.Println("unknown job type:", job.Type)
+		}
 	}
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log"
 	"taskmanager/internal/cache"
+	"taskmanager/internal/model"
 	"taskmanager/internal/queue"
 
 	envpkg "taskmanager/internal/config"
 	dbpkg "taskmanager/internal/db"
 	redispkg "taskmanager/internal/redis"
+
+	"github.com/redis/go-redis/v9"
 )
 
 func main() {
@@ -28,12 +33,20 @@ func main() {
 	// queue
 	q := queue.NewRedisQueue(rdb, "jobs")
 
+	// failed queue
+	qFailed := queue.NewRedisQueue(rdb, "jobs:failed")
+
 	// DB
 	db, err := dbpkg.Init()
 	if err != nil {
 		log.Fatalf("Failed to connect to DB: %v", err)
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Println("error closing db:", err)
+		}
+	}()
+
 	log.Println("worker connected to DB")
 
 	// worker loop
@@ -43,67 +56,97 @@ func main() {
 	for {
 		job, err := q.PopJob(ctx)
 		if err != nil {
-			log.Println("error:", err)
+			log.Println("pop error:", err)
+			continue
 		}
-		switch job.Type {
 
-		case "create_task":
-			var payload struct {
-				Title string `json:"title"`
+		log.Printf("processing job: %s (%d/%d)", job.Type, job.Retries, job.MaxRetry)
+
+		if err := handleJob(db, rdb, job); err != nil {
+			log.Println("job failed:", err)
+
+			if job.Retries < job.MaxRetry {
+				job.Retries++
+				log.Printf("retrying job (%d/%d)", job.Retries, job.MaxRetry)
+
+				if err := q.PushJob(ctx, *job); err != nil {
+					log.Println("failed to requeue job:", err)
+				}
+			} else {
+				log.Println("job permanently failed → moving to failed queue")
+
+				if err := qFailed.PushJob(ctx, *job); err != nil {
+					log.Println("failed to push to failed queue:", err)
+				}
 			}
 
-			if err := json.Unmarshal(job.Payload, &payload); err != nil {
-				log.Println("failed to parse payload:", err)
-				continue
-			}
-
-			if _, err = dbpkg.CreateTask(db, payload.Title); err != nil {
-				log.Println("failed to create task:", err)
-				continue
-			}
-
-			cache.InvalidateTasks(rdb)
-			log.Println("task created:", payload.Title)
-
-		case "delete_task":
-			var payload struct {
-				ID int `json:"id"`
-			}
-
-			if err := json.Unmarshal(job.Payload, &payload); err != nil {
-				log.Println("failed to parse payload:", err)
-				continue
-			}
-
-			if err := dbpkg.DeleteTask(db, payload.ID); err != nil {
-				log.Println("failed to delete task:", err)
-				continue
-
-			}
-
-			cache.InvalidateTasks(rdb)
-			log.Printf("Task %d deleted", payload.ID)
-
-		case "mark_task_done":
-			var payload struct {
-				ID int `json:"id"`
-			}
-
-			if err := json.Unmarshal(job.Payload, &payload); err != nil {
-				log.Println("failed to parse payload:", err)
-				continue
-			}
-
-			if _, err := dbpkg.UpdateTaskStatus(db, payload.ID, true); err != nil {
-				log.Println("failed to update task:", err)
-				continue
-			}
-
-			cache.InvalidateTasks(rdb)
-			log.Printf("Task id - %d has been updated to done", payload.ID)
-
-		default:
-			log.Println("unknown job type:", job.Type)
+			continue
 		}
+
+		log.Println("job succeeded:", job.Type)
+	}
+}
+
+func handleJob(db *sql.DB, rdb *redis.Client, job *model.Job) error {
+	switch job.Type {
+
+	case "create_task":
+		var payload struct {
+			Title string `json:"title"`
+		}
+
+		if err := json.Unmarshal(job.Payload, &payload); err != nil {
+			return err
+		}
+
+		if _, err := dbpkg.CreateTask(db, payload.Title); err != nil {
+
+			return err
+		}
+
+		cache.InvalidateTasks(rdb)
+		log.Println("task created:", payload.Title)
+		return nil
+		// for testing
+		//return fmt.Errorf("forced failure for testing")
+
+	case "delete_task":
+		var payload struct {
+			ID int `json:"id"`
+		}
+
+		if err := json.Unmarshal(job.Payload, &payload); err != nil {
+
+			return err
+		}
+
+		if err := dbpkg.DeleteTask(db, payload.ID); err != nil {
+			return err
+
+		}
+
+		cache.InvalidateTasks(rdb)
+		log.Printf("Task %d deleted", payload.ID)
+		return nil
+
+	case "mark_task_done":
+		var payload struct {
+			ID int `json:"id"`
+		}
+
+		if err := json.Unmarshal(job.Payload, &payload); err != nil {
+			return err
+		}
+
+		if _, err := dbpkg.UpdateTaskStatus(db, payload.ID, true); err != nil {
+			return err
+		}
+
+		cache.InvalidateTasks(rdb)
+		log.Printf("Task id - %d has been updated to done", payload.ID)
+		return nil
+
+	default:
+		return fmt.Errorf("unknown job type: %s", job.Type)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,17 @@ services:
       timeout: 2s
       retries: 5
 
+  worker:
+    build: .
+    container_name: go_worker
+    command: [ "./worker" ]
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
   nginx:
     image: nginx:latest
     container_name: nginx_proxy

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,7 +38,7 @@ func registerRoutes(r *gin.Engine, db *sql.DB, rdb *redis.Client, q *queue.Redis
 	authorized.Use(middleware.AuthMiddleware())
 	authorized.GET("/tasks", GetTasksHandler(db, rdb))
 	authorized.POST("/tasks", CreateTaskHandler(q))
-	authorized.DELETE("/tasks/:id", DeleteTaskHandler(db, rdb))
+	authorized.DELETE("/tasks/:id", DeleteTaskHandler(q))
 	authorized.PATCH("/tasks/:id", UpdateTaskStatusHandler(db, rdb))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	middleware "taskmanager/internal/middleware"
+	"taskmanager/internal/queue"
 
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
@@ -12,19 +13,19 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
-func Start(db *sql.DB, rdb *redis.Client) {
+func Start(db *sql.DB, rdb *redis.Client, q *queue.RedisQueue) {
 	r := gin.Default()
 
 	r.Use(middleware.RateLimiter())
 
-	registerRoutes(r, db, rdb)
+	registerRoutes(r, db, rdb, q)
 
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func registerRoutes(r *gin.Engine, db *sql.DB, rdb *redis.Client) {
+func registerRoutes(r *gin.Engine, db *sql.DB, rdb *redis.Client, q *queue.RedisQueue) {
 
 	//health
 	r.GET("/health", HealthHandler(db))
@@ -36,7 +37,7 @@ func registerRoutes(r *gin.Engine, db *sql.DB, rdb *redis.Client) {
 	authorized := r.Group("/")
 	authorized.Use(middleware.AuthMiddleware())
 	authorized.GET("/tasks", GetTasksHandler(db, rdb))
-	authorized.POST("/tasks", CreateTaskHandler(db, rdb))
+	authorized.POST("/tasks", CreateTaskHandler(q))
 	authorized.DELETE("/tasks/:id", DeleteTaskHandler(db, rdb))
 	authorized.PATCH("/tasks/:id", UpdateTaskStatusHandler(db, rdb))
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -39,7 +39,7 @@ func registerRoutes(r *gin.Engine, db *sql.DB, rdb *redis.Client, q *queue.Redis
 	authorized.GET("/tasks", GetTasksHandler(db, rdb))
 	authorized.POST("/tasks", CreateTaskHandler(q))
 	authorized.DELETE("/tasks/:id", DeleteTaskHandler(q))
-	authorized.PATCH("/tasks/:id", UpdateTaskStatusHandler(db, rdb))
+	authorized.PATCH("/tasks/:id", UpdateTaskStatusHandler(q))
 
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 }

--- a/internal/api/task_handler.go
+++ b/internal/api/task_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	model "taskmanager/internal/model"
+	"taskmanager/internal/queue"
 	servicepkg "taskmanager/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -77,7 +78,7 @@ type CreateTaskRequest struct {
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /tasks [post]
-func CreateTaskHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
+func CreateTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		var body CreateTaskRequest
@@ -94,16 +95,14 @@ func CreateTaskHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
 			return
 		}
 
-		//call service
-		id, err := servicepkg.CreateTask(db, rdb, body.Title)
+		//call service (queue now)
+		err := servicepkg.CreateTask(q, body.Title)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 		c.JSON(http.StatusCreated, gin.H{
-			"id":    id,
-			"title": body.Title,
-			"done":  false,
+			"message": "task queued",
 		})
 	}
 }

--- a/internal/api/task_handler.go
+++ b/internal/api/task_handler.go
@@ -101,7 +101,7 @@ func CreateTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		c.JSON(http.StatusCreated, gin.H{
+		c.JSON(http.StatusAccepted, gin.H{
 			"message": "task queued",
 		})
 	}
@@ -132,7 +132,7 @@ func DeleteTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 		}
 
 		//c.Status(http.StatusNoContent) // 204
-		c.JSON(http.StatusCreated, gin.H{
+		c.JSON(http.StatusAccepted, gin.H{
 			"message": "task queued",
 		})
 	}
@@ -147,7 +147,7 @@ func DeleteTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
 // @Router /tasks/{id} [patch]
-func UpdateTaskStatusHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
+func UpdateTaskStatusHandler(q *queue.RedisQueue) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		idStr := c.Param("id")
 		id, err := strconv.Atoi(idStr)
@@ -156,12 +156,14 @@ func UpdateTaskStatusHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
 			return
 		}
 
-		task, err := servicepkg.MarkTaskDone(db, rdb, id)
-		if err != nil {
+		if err := servicepkg.MarkTaskDone(id, q); err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "task not found"})
 			return
+
 		}
 
-		c.JSON(http.StatusOK, task)
+		c.JSON(http.StatusAccepted, gin.H{
+			"message": "task queued",
+		})
 	}
 }

--- a/internal/api/task_handler.go
+++ b/internal/api/task_handler.go
@@ -116,7 +116,7 @@ func CreateTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
 // @Router /tasks/{id} [delete]
-func DeleteTaskHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
+func DeleteTaskHandler(q *queue.RedisQueue) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		idStr := c.Param("id")
 		id, err := strconv.Atoi(idStr)
@@ -125,13 +125,16 @@ func DeleteTaskHandler(db *sql.DB, rdb *redis.Client) gin.HandlerFunc {
 			return
 		}
 
-		err = servicepkg.DeleteTask(db, rdb, id)
+		err = servicepkg.DeleteTask(id, q)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "task not found"})
 			return
 		}
 
-		c.Status(http.StatusNoContent) // 204
+		//c.Status(http.StatusNoContent) // 204
+		c.JSON(http.StatusCreated, gin.H{
+			"message": "task queued",
+		})
 	}
 }
 

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -1,0 +1,8 @@
+package model
+
+import "encoding/json"
+
+type Job struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -3,6 +3,8 @@ package model
 import "encoding/json"
 
 type Job struct {
-	Type    string          `json:"type"`
-	Payload json.RawMessage `json:"payload"`
+	Type     string          `json:"type"`
+	Payload  json.RawMessage `json:"payload"`
+	Retries  int             `json:"retries"`
+	MaxRetry int             `josn:"max_retry"`
 }

--- a/internal/queue/redis_queue.go
+++ b/internal/queue/redis_queue.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"taskmanager/internal/model"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type RedisQueue struct {
+	client *redis.Client
+	key    string
+}
+
+func NewRedisQueue(client *redis.Client, key string) *RedisQueue {
+	return &RedisQueue{
+		client: client,
+		key:    key,
+	}
+}
+
+func (q *RedisQueue) PushJob(ctx context.Context, job model.Job) error {
+	// step 1 ) convert job -> JSON
+	data, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	// step 2 ) push into redis list
+	return q.client.LPush(ctx, q.key, data).Err()
+}
+func (q *RedisQueue) PopJob(ctx context.Context) (*model.Job, error) {
+	// step 1 ) block and wait for the job
+	result, err := q.client.BRPop(ctx, 0, q.key).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	// step 2 ) extract job data
+	data := result[1]
+
+	// step 3 ) convert json to job struct
+	var job model.Job
+	if err := json.Unmarshal([]byte(data), &job); err != nil {
+		return nil, err
+	}
+
+	// step 4 ) return job
+	return &job, nil
+}

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -48,12 +48,6 @@ func CreateTask(q *queue.RedisQueue, title string) error {
 }
 
 func DeleteTask(id int, q *queue.RedisQueue) error {
-	// err := dbpkg.DeleteTask(db, id)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// cache.InvalidateTasks(rdb)
 
 	if id <= 0 {
 		return fmt.Errorf("Invalid id")
@@ -74,12 +68,24 @@ func DeleteTask(id int, q *queue.RedisQueue) error {
 	return q.PushJob(context.Background(), job)
 }
 
-func MarkTaskDone(db *sql.DB, rdb *redis.Client, id int) (model.Task, error) {
-	task, err := dbpkg.UpdateTaskStatus(db, id, true)
-	if err != nil {
-		return model.Task{}, err
+func MarkTaskDone(id int, q *queue.RedisQueue) error {
+
+	if id <= 0 {
+		return fmt.Errorf("Invalid id")
 	}
 
-	cache.InvalidateTasks(rdb)
-	return task, nil
+	payload, err := json.Marshal(struct {
+		ID int `json:"id"`
+	}{ID: id})
+
+	if err != nil {
+		return err
+	}
+
+	job := model.Job{
+		Type:    "mark_task_done",
+		Payload: payload,
+	}
+
+	return q.PushJob(context.Background(), job)
 }

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -40,8 +40,10 @@ func CreateTask(q *queue.RedisQueue, title string) error {
 	}
 
 	job := model.Job{
-		Type:    "create_task",
-		Payload: payload,
+		Type:     "create_task",
+		Payload:  payload,
+		Retries:  0,
+		MaxRetry: 3,
 	}
 
 	return q.PushJob(context.Background(), job)
@@ -50,7 +52,7 @@ func CreateTask(q *queue.RedisQueue, title string) error {
 func DeleteTask(id int, q *queue.RedisQueue) error {
 
 	if id <= 0 {
-		return fmt.Errorf("Invalid id")
+		return fmt.Errorf("invalid id")
 	}
 
 	payload, err := json.Marshal(struct {
@@ -61,8 +63,10 @@ func DeleteTask(id int, q *queue.RedisQueue) error {
 	}
 
 	job := model.Job{
-		Type:    "delete_task",
-		Payload: payload,
+		Type:     "delete_task",
+		Payload:  payload,
+		Retries:  0,
+		MaxRetry: 3,
 	}
 
 	return q.PushJob(context.Background(), job)
@@ -71,7 +75,7 @@ func DeleteTask(id int, q *queue.RedisQueue) error {
 func MarkTaskDone(id int, q *queue.RedisQueue) error {
 
 	if id <= 0 {
-		return fmt.Errorf("Invalid id")
+		return fmt.Errorf("invalid id")
 	}
 
 	payload, err := json.Marshal(struct {
@@ -83,8 +87,10 @@ func MarkTaskDone(id int, q *queue.RedisQueue) error {
 	}
 
 	job := model.Job{
-		Type:    "mark_task_done",
-		Payload: payload,
+		Type:     "mark_task_done",
+		Payload:  payload,
+		Retries:  0,
+		MaxRetry: 3,
 	}
 
 	return q.PushJob(context.Background(), job)

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -1,11 +1,14 @@
 package service
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"taskmanager/internal/cache"
 	dbpkg "taskmanager/internal/db"
 	model "taskmanager/internal/model"
+	"taskmanager/internal/queue"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -25,19 +28,37 @@ func GetTasks(db *sql.DB, rdb *redis.Client, filter string, limit int, offset in
 
 	return dbpkg.GetTasks(db, filter, limit, offset)
 }
-
-func CreateTask(db *sql.DB, rdb *redis.Client, title string) (int64, error) {
+func CreateTask(q *queue.RedisQueue, title string) error {
 	if title == "" {
-		return 0, fmt.Errorf("title cannot be empty")
+		return fmt.Errorf("title cannot be empty")
 	}
-	id, err := dbpkg.CreateTask(db, title)
+	payload, err := json.Marshal(struct {
+		Title string `json:"title"`
+	}{Title: title})
 	if err != nil {
-		return id, err
+		return err
 	}
 
-	cache.InvalidateTasks(rdb)
-	return id, nil
+	job := model.Job{
+		Type:    "create_task",
+		Payload: payload,
+	}
+
+	return q.PushJob(context.Background(), job)
 }
+
+// func CreateTask(db *sql.DB, rdb *redis.Client, title string) (int64, error) {
+// 	if title == "" {
+// 		return 0, fmt.Errorf("title cannot be empty")
+// 	}
+// 	id, err := dbpkg.CreateTask(db, title)
+// 	if err != nil {
+// 		return id, err
+// 	}
+
+// 	cache.InvalidateTasks(rdb)
+// 	return id, nil
+// }
 
 func DeleteTask(db *sql.DB, rdb *redis.Client, id int) error {
 	err := dbpkg.DeleteTask(db, id)

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -47,28 +47,31 @@ func CreateTask(q *queue.RedisQueue, title string) error {
 	return q.PushJob(context.Background(), job)
 }
 
-// func CreateTask(db *sql.DB, rdb *redis.Client, title string) (int64, error) {
-// 	if title == "" {
-// 		return 0, fmt.Errorf("title cannot be empty")
-// 	}
-// 	id, err := dbpkg.CreateTask(db, title)
-// 	if err != nil {
-// 		return id, err
-// 	}
+func DeleteTask(id int, q *queue.RedisQueue) error {
+	// err := dbpkg.DeleteTask(db, id)
+	// if err != nil {
+	// 	return err
+	// }
 
-// 	cache.InvalidateTasks(rdb)
-// 	return id, nil
-// }
+	// cache.InvalidateTasks(rdb)
 
-func DeleteTask(db *sql.DB, rdb *redis.Client, id int) error {
-	err := dbpkg.DeleteTask(db, id)
+	if id <= 0 {
+		return fmt.Errorf("Invalid id")
+	}
+
+	payload, err := json.Marshal(struct {
+		ID int `json:"id"`
+	}{ID: id})
 	if err != nil {
 		return err
 	}
 
-	cache.InvalidateTasks(rdb)
+	job := model.Job{
+		Type:    "delete_task",
+		Payload: payload,
+	}
 
-	return nil
+	return q.PushJob(context.Background(), job)
 }
 
 func MarkTaskDone(db *sql.DB, rdb *redis.Client, id int) (model.Task, error) {


### PR DESCRIPTION
## Summary
Introduces basic retry handling and a dead-letter queue for async jobs processed by the Redis worker.

## Changes
- Added retries + maxRetry fields to Job model
- Implemented retry loop in worker (at-least-once, basic)
- Moved failed jobs to `jobs:failed` after max retries
- Extracted job handling into handleJob()
- Kept API write endpoints async (202 Accepted)

## How to test
1. Start services: `docker compose up --build`
2. (Optional) Force a failure in handleJob to observe retries
3. POST /tasks → observe retries in worker logs
4. Verify failed jobs:
   `docker exec -it redis_cache redis-cli`
   `LRANGE jobs:failed 0 -1`
5. Remove forced failure → POST again → job succeeds

## Notes / Limitations
- No retry delay/backoff yet
- Possible job loss if worker crashes after pop (no ack/visibility timeout)