### PR TITLE
wip: nginx https setup complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ temp/
 # JSON data (optional)
 # If tasks.json is just local data, ignore it:
 # tasks.json
+
+
+# SSL certs
+nginx/certs/*
+!nginx/certs/.gitkeep

--- a/DEV_NOTES.MD
+++ b/DEV_NOTES.MD
@@ -1,0 +1,42 @@
+## ⚠️ Windows / Git Bash Notes (OpenSSL Path Issue)
+
+When generating SSL certificates using `openssl` in Git Bash (MSYS/Cygwin), paths that start with `/` may be incorrectly converted into Windows-style paths.
+
+### ❌ Problem
+
+Running:
+
+```
+openssl req ... -subj "/CN=localhost"
+```
+
+may result in an error like:
+
+```
+subject name is not in that format: 'C:/Program Files/Git/CN=localhost'
+```
+
+### ✅ Solution
+
+Disable path conversion for this command:
+
+```
+MSYS_NO_PATHCONV=1 openssl req -x509 -nodes -days 365 \
+  -newkey rsa:2048 \
+  -keyout nginx/certs/key.pem \
+  -out nginx/certs/cert.pem \
+  -subj "/CN=localhost"
+```
+
+### 🧠 Explanation
+
+Git Bash automatically rewrites paths like `/something` into Windows paths (e.g., `C:\...`).
+This breaks tools like OpenSSL that expect Unix-style input.
+
+Setting `MSYS_NO_PATHCONV=1` prevents this behavior.
+
+### 🔁 Alternative
+
+Use WSL (Windows Subsystem for Linux) to avoid these issues entirely when working with Unix-based tools.
+
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,10 @@ services:
 
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/certs:/etc/nginx/certs
     depends_on:
       app:
         condition: service_healthy

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,11 +10,24 @@ http {
         server app2:8080;
     }
 
+    # https server
     server {
-        listen 80;
+        listen 443 ssl;
+
+        ssl_certificate /etc/nginx/certs/cert.pem;
+        ssl_certificate_key /etc/nginx/certs/key.pem;
 
         location / {
             proxy_pass http://app_backend;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
         }
+    }
+
+    # http -> https redirect
+    server {
+        listen 80;
+        return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
Adds HTTPS support to the application using SSL/TLS termination at the NGINX layer.

Changes:
- Configured NGINX to listen on port 443 with SSL
- Added HTTP → HTTPS redirect (301)
- Generated and mounted self-signed certificates for local development
- Integrated HTTPS with existing upstream load balancing setup

Verification:
- HTTPS endpoint accessible via https://localhost
- HTTP requests are redirected to HTTPS
- Load balancing across multiple API instances remains functional
- Authentication and API functionality unaffected