### PR TITLE
feat(security): add nginx rate limiting and return 429 on excess traffic

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,6 +5,8 @@ events {
 http {
     resolver 127.0.0.11;
 
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=5r/s;
+
     upstream app_backend {
         server app:8080;
         server app2:8080;
@@ -30,6 +32,9 @@ http {
 
         location / {
             proxy_pass http://app_backend;
+
+            limit_req zone=api_limit burst=10 nodelay;
+            limit_req_status 429;
 
             # Forward Headers
             proxy_set_header Host $host;


### PR DESCRIPTION
- Implemented rate limiting using limit_req
- Configured burst handling and nodelay
- Added limit_req_status 429 for proper responses
- Tested under concurrent load (429 + rejection observed)

This protects backend services from excessive traffic at the edge.